### PR TITLE
converted list to Markdown; appended "moving between cultures" user story

### DIFF
--- a/user-stories.md
+++ b/user-stories.md
@@ -1,4 +1,4 @@
-The Minimum Viable Set of User Stories.
+# The Minimum Viable Set of User Stories.
 
 - User changes email addresses
 - User changes physical addresses
@@ -20,3 +20,4 @@ The Minimum Viable Set of User Stories.
 - User is targeted for abuse by a corporation
 - User is targeted for abuse by a nation-state
 - User is a member of a group or demographic targeted for abuse by an informally organized group
+- User is moving between cultures


### PR DESCRIPTION
The list was converted from a text file to a Markdown file with the two-byte substitution of `-` with `#` on the title line of the file, plus a rename from `.txt` to `.md`.

More importantly, I appended one additional story: "_user is moving between cultures_".  My intention here was to capture the general case of someone moving between countries, or continents, or time zones; to capture situations such as the ones documented in [Culture Shock](http://exple.tive.org/blarg/2016/08/18/culture-shock/) / [Adjusting To A New Environment](https://drive.google.com/file/d/0B_hkX0w0BMT4UkpDQVpkWE5GTEE/view?usp=sharing); or even crossing the urban/rural divide, in either direction.
# Arguments Opposing

The challenges presented by this story overlap somewhat with:
- User changes physical addresses
- User is not always, and/or or not reliably, connected to the internet
- User is estranged from their family
- User is trying to escape **...**

Possibly also:
- User is not always, and/or or not reliably, connected to the internet
# Arguments in Favour

Integrating into a new culture presents challenges and draws on resources not fully captured by the overlapping stories, eg. being _technically_ able to contact and draw on existing support networks but only with significantly increased activation energy (time zone differences, long distance charges, &c), which draws on emotional reserves being drained by the very integration work requiring support.
